### PR TITLE
Modified AddJob to remove existing job if job is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ GoJek Commons is built on top of [Dropwizard Framework](http://www.dropwizard.io
 ## Getting Started 
 
 ### Setting Up Maven
+
 ```xml
    <dependencies>
      <dependency>


### PR DESCRIPTION
Currently, if a job had been enabled and is existing in quartz DB, disabling the job later would not removed entries from the DB making unwanted jobs to be running for a scheduler.

This change, deletes an existing job(if any) when a job is disabled. This will keep the job configurations and data is quartz tables consistent.