### PR TITLE
Enable rabbitmq QoS(prefetchCount) setting

### DIFF
--- a/gojek-commons-amqp/src/main/java/com/gojek/amqp/AmqpConsumerContainer.java
+++ b/gojek-commons-amqp/src/main/java/com/gojek/amqp/AmqpConsumerContainer.java
@@ -26,6 +26,8 @@ public class AmqpConsumerContainer<E> implements Consumer.ShutdownListener, Mana
 	private String queueName;
 	
 	private int maxConsumers;
+
+	private Integer prefetchCount;
 	
 	private List<AmqpConsumer<E>> consumers;
 	
@@ -43,6 +45,7 @@ public class AmqpConsumerContainer<E> implements Consumer.ShutdownListener, Mana
 	public AmqpConsumerContainer(ConsumerConfiguration configuration, EventHandler<E> handler, AmqpConnection connection) {
 		this.queueName = configuration.getQueueName();
 		this.maxConsumers = configuration.getMaxQueueConsumers();
+		this.prefetchCount = configuration.getPrefetchCount();
 		this.handler = handler;
 		this.connection = connection;
 		this.consumers = Lists.newArrayList();
@@ -77,7 +80,7 @@ public class AmqpConsumerContainer<E> implements Consumer.ShutdownListener, Mana
 	 * @return
 	 */
 	protected AmqpConsumer<E> createConsumer(Channel channel) {
-		return new AmqpConsumer<E>(queueName, channel, handler, this);
+		return new AmqpConsumer<E>(queueName, prefetchCount, channel, handler, this);
 	}
 	
 	/**

--- a/gojek-commons-amqp/src/main/java/com/gojek/amqp/event/AmqpConsumer.java
+++ b/gojek-commons-amqp/src/main/java/com/gojek/amqp/event/AmqpConsumer.java
@@ -28,6 +28,8 @@ public class AmqpConsumer<E> extends DefaultConsumer implements Consumer<E> {
 	private EventHandler<E> handler;
 	
 	private String queueName;
+
+	private Integer prefetchCount;
 	
 	private Consumer.ShutdownListener shutdownListener;
 	
@@ -39,9 +41,10 @@ public class AmqpConsumer<E> extends DefaultConsumer implements Consumer<E> {
 	 * @param handler
 	 * @param shutdownListener
 	 */
-	public AmqpConsumer(String queueName, Channel channel, EventHandler<E> handler, Consumer.ShutdownListener shutdownListener) {
+	public AmqpConsumer(String queueName, Integer prefetchCount, Channel channel, EventHandler<E> handler, Consumer.ShutdownListener shutdownListener) {
 		super(channel);
 		this.queueName = queueName;
+		this.prefetchCount = prefetchCount;
 		this.handler = handler;
 		this.shutdownListener = shutdownListener;
 	}
@@ -94,6 +97,7 @@ public class AmqpConsumer<E> extends DefaultConsumer implements Consumer<E> {
 	@Override
 	public void start() {
 		try {
+			getChannel().basicQos(prefetchCount, true);
 			getChannel().basicConsume(queueName, false, this);
 		} catch (IOException e) {
 			logger.error("Failed while starting the consumer", e);

--- a/gojek-commons-core/src/main/java/com/gojek/core/event/ConsumerConfiguration.java
+++ b/gojek-commons-core/src/main/java/com/gojek/core/event/ConsumerConfiguration.java
@@ -12,6 +12,8 @@ public class ConsumerConfiguration {
     private Destination retryDestination;
     
     private String queueName;
+
+    private Integer prefetchCount = 0;
     
     private Integer maxRetries = DEFAULT_MAX_RETRIES;
     
@@ -102,5 +104,13 @@ public class ConsumerConfiguration {
      */
     public void setMaxQueueConsumers(Integer maxQueueConsumers) {
         this.maxQueueConsumers = maxQueueConsumers;
+    }
+
+    public Integer getPrefetchCount() {
+        return prefetchCount;
+    }
+
+    public void setPrefetchCount(Integer prefetchCount) {
+        this.prefetchCount = prefetchCount;
     }
 }


### PR DESCRIPTION
Enable to add QoS(prefetchCount) setting to consumer and controls the broker traffic to rabbitmq consumer